### PR TITLE
Configure stack navigation for mobile app

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+
+import HomeScreen from './src/screens/HomeScreen';
+import CategoriesScreen from './src/screens/CategoriesScreen';
+import SearchScreen from './src/screens/SearchScreen';
+import BusinessListScreen from './src/screens/BusinessListScreen';
+import BusinessDetailScreen from './src/screens/BusinessDetailScreen';
+import FavoritesScreen from './src/screens/FavoritesScreen';
+
+const Stack = createStackNavigator();
+
+const App = () => {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator
+        initialRouteName="HomeScreen"
+        screenOptions={{
+          headerBackTitleVisible: false,
+        }}
+      >
+        <Stack.Screen name="HomeScreen" component={HomeScreen} options={{ title: 'Inicio' }} />
+        <Stack.Screen name="CategoriesScreen" component={CategoriesScreen} options={{ title: 'Categorías' }} />
+        <Stack.Screen name="SearchScreen" component={SearchScreen} options={{ title: 'Buscar' }} />
+        <Stack.Screen name="BusinessListScreen" component={BusinessListScreen} options={{ title: 'Negocios' }} />
+        <Stack.Screen
+          name="BusinessDetailScreen"
+          component={BusinessDetailScreen}
+          options={{ title: 'Detalle del negocio' }}
+        />
+        <Stack.Screen name="FavoritesScreen" component={FavoritesScreen} options={{ title: 'Favoritos' }} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+};
+
+export default App;

--- a/src/screens/BusinessDetailScreen.js
+++ b/src/screens/BusinessDetailScreen.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const BusinessDetailScreen = () => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Business Detail Screen</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+});
+
+export default BusinessDetailScreen;

--- a/src/screens/BusinessListScreen.js
+++ b/src/screens/BusinessListScreen.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const BusinessListScreen = () => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Business List Screen</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+});
+
+export default BusinessListScreen;

--- a/src/screens/CategoriesScreen.js
+++ b/src/screens/CategoriesScreen.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const CategoriesScreen = () => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Categories Screen</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+});
+
+export default CategoriesScreen;

--- a/src/screens/FavoritesScreen.js
+++ b/src/screens/FavoritesScreen.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const FavoritesScreen = () => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Favorites Screen</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+});
+
+export default FavoritesScreen;

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const HomeScreen = () => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Home Screen</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+});
+
+export default HomeScreen;

--- a/src/screens/SearchScreen.js
+++ b/src/screens/SearchScreen.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const SearchScreen = () => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Search Screen</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+});
+
+export default SearchScreen;


### PR DESCRIPTION
## Summary
- add the navigation container and stack navigator configured with the required screens in `App.js`
- scaffold placeholder screen components for the different app sections so the navigator has concrete targets

## Testing
- not run (project type not configured for automated tests yet)


------
https://chatgpt.com/codex/tasks/task_e_68cb4cfc31a88330b1658dabadf7f680