### PR TITLE
feat: add categories screen navigation

### DIFF
--- a/screens/CategoriesScreen.js
+++ b/screens/CategoriesScreen.js
@@ -1,0 +1,77 @@
+import React, { useCallback } from 'react';
+import { View, Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native';
+
+const CATEGORIES = [
+  'Alimentos y Bebidas',
+  'Salud y Bienestar',
+  'Servicios Profesionales',
+  'Educación',
+  'Hogar y Mejoras',
+  'Entretenimiento',
+  'Automotriz',
+  'Tecnología',
+];
+
+const CategoriesScreen = ({ navigation }) => {
+  const handleCategoryPress = useCallback(
+    (category) => {
+      if (navigation && typeof navigation.navigate === 'function') {
+        navigation.navigate('BusinessListScreen', { category });
+      }
+    },
+    [navigation]
+  );
+
+  const renderCategory = ({ item }) => (
+    <TouchableOpacity
+      style={styles.categoryButton}
+      onPress={() => handleCategoryPress(item)}
+    >
+      <Text style={styles.categoryLabel}>{item}</Text>
+    </TouchableOpacity>
+  );
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Categorías</Text>
+      <FlatList
+        data={CATEGORIES}
+        keyExtractor={(item) => item}
+        renderItem={renderCategory}
+        contentContainerStyle={styles.listContent}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: 16,
+    paddingTop: 24,
+    backgroundColor: '#FFFFFF',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  listContent: {
+    paddingBottom: 24,
+  },
+  categoryButton: {
+    backgroundColor: '#1d4ed8',
+    paddingVertical: 16,
+    borderRadius: 8,
+    marginBottom: 12,
+    alignItems: 'center',
+  },
+  categoryLabel: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});
+
+export default CategoriesScreen;


### PR DESCRIPTION
## Summary
- add a React Native categories screen that lists the available categories as buttons
- navigate to `BusinessListScreen` with the selected category when a button is pressed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb4f4771b88330b9352881225202a4