### PR TITLE
Implement dummy business list screen with category filtering

### DIFF
--- a/App.js
+++ b/App.js
@@ -23,9 +23,9 @@ const App = () => {
         <Stack.Screen name="HomeScreen" component={HomeScreen} options={{ title: 'Inicio' }} />
         <Stack.Screen name="CategoriesScreen" component={CategoriesScreen} options={{ title: 'Categorías' }} />
         <Stack.Screen name="SearchScreen" component={SearchScreen} options={{ title: 'Buscar' }} />
-        <Stack.Screen name="BusinessListScreen" component={BusinessListScreen} options={{ title: 'Negocios' }} />
+        <Stack.Screen name="BusinessList" component={BusinessListScreen} options={{ title: 'Negocios' }} />
         <Stack.Screen
-          name="BusinessDetailScreen"
+          name="BusinessDetail"
           component={BusinessDetailScreen}
           options={{ title: 'Detalle del negocio' }}
         />

--- a/screens/BusinessListScreen.js
+++ b/screens/BusinessListScreen.js
@@ -1,71 +1,170 @@
 import React, { useMemo } from 'react';
-import { View, Text, FlatList, StyleSheet } from 'react-native';
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  StyleSheet,
+} from 'react-native';
 
-const MOCK_BUSINESSES = [
+const BUSINESSES = [
   {
-    id: '1',
-    name: 'Panadería La Delicia',
-    address: 'Calle 21 #145, Caucel',
-    category: 'Alimentos',
+    id: 'alimentos-1',
+    name: 'Cafetería Aroma Maya',
+    address: 'Calle 20 #145, Caucel',
+    category: 'Alimentos y Bebidas',
+    phone: '+529999876543',
   },
   {
-    id: '2',
-    name: 'Farmacia Caucel',
-    address: 'Avenida 50 #210, Caucel',
-    category: 'Salud',
+    id: 'alimentos-2',
+    name: 'Heladería Dulce Cielo',
+    address: 'Av. 70 #210, Caucel',
+    category: 'Alimentos y Bebidas',
+    phone: '+529998765432',
   },
   {
-    id: '3',
-    name: 'Gimnasio Energía',
-    address: 'Calle 31 #120, Caucel',
-    category: 'Deporte',
+    id: 'salud-1',
+    name: 'Clínica Bienestar Caucel',
+    address: 'Calle 31 #98, Caucel',
+    category: 'Salud y Bienestar',
+    phone: '+529997654321',
   },
   {
-    id: '4',
-    name: 'Cafetería Aromas',
-    address: 'Calle 19 #98, Caucel',
-    category: 'Alimentos',
-  },
-  {
-    id: '5',
-    name: 'Clínica Dental Sonrisas',
+    id: 'salud-2',
+    name: 'Farmacia Vida Plena',
     address: 'Calle 14 #56, Caucel',
-    category: 'Salud',
+    category: 'Salud y Bienestar',
+    phone: '+529996543210',
+  },
+  {
+    id: 'servicios-1',
+    name: 'Consultoría Caucel Pro',
+    address: 'Calle 19 #42, Caucel',
+    category: 'Servicios Profesionales',
+    phone: '+529995432109',
+  },
+  {
+    id: 'servicios-2',
+    name: 'Despacho Legal Caucel',
+    address: 'Av. 60 #130, Caucel',
+    category: 'Servicios Profesionales',
+    phone: '+529994321098',
+  },
+  {
+    id: 'educacion-1',
+    name: 'Academia Brilla',
+    address: 'Calle 18 #221, Caucel',
+    category: 'Educación',
+    phone: '+529993210987',
+  },
+  {
+    id: 'educacion-2',
+    name: 'Centro de Idiomas Caucel',
+    address: 'Calle 15 #87, Caucel',
+    category: 'Educación',
+    phone: '+529992109876',
+  },
+  {
+    id: 'hogar-1',
+    name: 'Ferretería La Herramienta',
+    address: 'Av. 65 #34, Caucel',
+    category: 'Hogar y Mejoras',
+    phone: '+529991098765',
+  },
+  {
+    id: 'hogar-2',
+    name: 'Decoraciones Casa Viva',
+    address: 'Calle 24 #150, Caucel',
+    category: 'Hogar y Mejoras',
+    phone: '+529990987654',
+  },
+  {
+    id: 'entretenimiento-1',
+    name: 'CineClub Caucel',
+    address: 'Calle 12 #45, Caucel',
+    category: 'Entretenimiento',
+    phone: '+529989876543',
+  },
+  {
+    id: 'entretenimiento-2',
+    name: 'Parque de Diversiones Caucel',
+    address: 'Av. 30 #200, Caucel',
+    category: 'Entretenimiento',
+    phone: '+529988765432',
+  },
+  {
+    id: 'automotriz-1',
+    name: 'Taller Motor Max',
+    address: 'Calle 40 #180, Caucel',
+    category: 'Automotriz',
+    phone: '+529987654321',
+  },
+  {
+    id: 'automotriz-2',
+    name: 'Refaccionaria Ruta 281',
+    address: 'Calle 22 #78, Caucel',
+    category: 'Automotriz',
+    phone: '+529986543210',
+  },
+  {
+    id: 'tecnologia-1',
+    name: 'TechZone Caucel',
+    address: 'Av. 59 #300, Caucel',
+    category: 'Tecnología',
+    phone: '+529985432109',
+  },
+  {
+    id: 'tecnologia-2',
+    name: 'Servicios IT Caucel',
+    address: 'Calle 27 #66, Caucel',
+    category: 'Tecnología',
+    phone: '+529984321098',
   },
 ];
 
-const BusinessListScreen = ({ route }) => {
+const BusinessListScreen = ({ route, navigation }) => {
   const category = route?.params?.category ?? null;
 
-  const filteredBusinesses = useMemo(() => {
+  const businesses = useMemo(() => {
     if (!category) {
-      return MOCK_BUSINESSES;
+      return BUSINESSES;
     }
 
-    return MOCK_BUSINESSES.filter((business) => business.category === category);
+    return BUSINESSES.filter((business) => business.category === category);
   }, [category]);
 
   const renderBusiness = ({ item }) => (
     <View style={styles.card}>
-      <Text style={styles.name}>{item.name}</Text>
-      <Text style={styles.address}>{item.address}</Text>
-      <Text style={styles.category}>{item.category}</Text>
+      <View style={styles.cardInfo}>
+        <Text style={styles.name}>{item.name}</Text>
+        <Text style={styles.address}>{item.address}</Text>
+        {!category && <Text style={styles.category}>{item.category}</Text>}
+      </View>
+
+      <TouchableOpacity
+        style={styles.detailButton}
+        onPress={() => navigation?.navigate('BusinessDetail', { business: item })}
+      >
+        <Text style={styles.detailButtonText}>Ver detalle</Text>
+      </TouchableOpacity>
     </View>
   );
 
   return (
     <View style={styles.container}>
       <Text style={styles.header}>
-        {category ? `Negocios de ${category}` : 'Negocios disponibles'}
+        {category ? `Negocios de ${category}` : 'Todos los negocios'}
       </Text>
 
       <FlatList
-        data={filteredBusinesses}
+        data={businesses}
         keyExtractor={(item) => item.id}
         renderItem={renderBusiness}
         contentContainerStyle={styles.listContent}
         ListEmptyComponent={
-          <Text style={styles.emptyText}>No hay negocios en esta categoría.</Text>
+          <Text style={styles.emptyMessage}>
+            No hay negocios registrados para esta categoría.
+          </Text>
         }
       />
     </View>
@@ -75,13 +174,14 @@ const BusinessListScreen = ({ route }) => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#f2f2f2',
+    backgroundColor: '#f8fafc',
     paddingHorizontal: 16,
     paddingTop: 24,
   },
   header: {
     fontSize: 20,
     fontWeight: '700',
+    color: '#0f172a',
     marginBottom: 16,
   },
   listContent: {
@@ -89,34 +189,48 @@ const styles = StyleSheet.create({
     gap: 12,
   },
   card: {
-    backgroundColor: '#fff',
-    padding: 16,
+    backgroundColor: '#ffffff',
     borderRadius: 12,
+    padding: 16,
     shadowColor: '#000',
     shadowOpacity: 0.1,
-    shadowOffset: { width: 0, height: 2 },
     shadowRadius: 6,
+    shadowOffset: { width: 0, height: 2 },
     elevation: 3,
+  },
+  cardInfo: {
+    marginBottom: 12,
+    gap: 4,
   },
   name: {
     fontSize: 18,
     fontWeight: '600',
-    marginBottom: 6,
+    color: '#1e293b',
   },
   address: {
     fontSize: 14,
-    color: '#555',
-    marginBottom: 4,
+    color: '#475569',
   },
   category: {
     fontSize: 12,
-    fontWeight: '500',
-    color: '#1f7a8c',
+    color: '#64748b',
     textTransform: 'uppercase',
+    fontWeight: '600',
   },
-  emptyText: {
+  detailButton: {
+    backgroundColor: '#2563eb',
+    borderRadius: 8,
+    paddingVertical: 10,
+    alignItems: 'center',
+  },
+  detailButtonText: {
+    color: '#ffffff',
+    fontWeight: '600',
+    fontSize: 14,
+  },
+  emptyMessage: {
     textAlign: 'center',
-    color: '#777',
+    color: '#64748b',
     marginTop: 32,
   },
 });

--- a/screens/CategoriesScreen.js
+++ b/screens/CategoriesScreen.js
@@ -16,7 +16,7 @@ const CategoriesScreen = ({ navigation }) => {
   const handleCategoryPress = useCallback(
     (category) => {
       if (navigation && typeof navigation.navigate === 'function') {
-        navigation.navigate('BusinessListScreen', { category });
+        navigation.navigate('BusinessList', { category });
       }
     },
     [navigation]

--- a/src/screens/BusinessDetailScreen.js
+++ b/src/screens/BusinessDetailScreen.js
@@ -1,10 +1,28 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 
-const BusinessDetailScreen = () => {
+const BusinessDetailScreen = ({ route }) => {
+  const business = route?.params?.business ?? {};
+  const { name, address, category, phone } = business;
+
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Business Detail Screen</Text>
+      <Text style={styles.name}>{name || 'Negocio sin nombre'}</Text>
+
+      <View style={styles.section}>
+        <Text style={styles.label}>Dirección</Text>
+        <Text style={styles.value}>{address || 'No disponible'}</Text>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.label}>Categoría</Text>
+        <Text style={styles.value}>{category || 'No disponible'}</Text>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.label}>Teléfono</Text>
+        <Text style={styles.value}>{phone || 'No disponible'}</Text>
+      </View>
     </View>
   );
 };
@@ -12,12 +30,28 @@ const BusinessDetailScreen = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
+    padding: 24,
+    backgroundColor: '#ffffff',
   },
-  title: {
+  name: {
     fontSize: 24,
-    fontWeight: 'bold',
+    fontWeight: '700',
+    color: '#1e293b',
+    marginBottom: 24,
+  },
+  section: {
+    marginBottom: 16,
+  },
+  label: {
+    fontSize: 14,
+    color: '#64748b',
+    marginBottom: 4,
+    textTransform: 'uppercase',
+    fontWeight: '600',
+  },
+  value: {
+    fontSize: 16,
+    color: '#0f172a',
   },
 });
 

--- a/src/screens/BusinessListScreen.js
+++ b/src/screens/BusinessListScreen.js
@@ -1,10 +1,172 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useMemo } from 'react';
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  StyleSheet,
+} from 'react-native';
 
-const BusinessListScreen = () => {
+const BUSINESSES = [
+  {
+    id: 'alimentos-1',
+    name: 'Cafetería Aroma Maya',
+    address: 'Calle 20 #145, Caucel',
+    category: 'Alimentos y Bebidas',
+    phone: '+529999876543',
+  },
+  {
+    id: 'alimentos-2',
+    name: 'Heladería Dulce Cielo',
+    address: 'Av. 70 #210, Caucel',
+    category: 'Alimentos y Bebidas',
+    phone: '+529998765432',
+  },
+  {
+    id: 'salud-1',
+    name: 'Clínica Bienestar Caucel',
+    address: 'Calle 31 #98, Caucel',
+    category: 'Salud y Bienestar',
+    phone: '+529997654321',
+  },
+  {
+    id: 'salud-2',
+    name: 'Farmacia Vida Plena',
+    address: 'Calle 14 #56, Caucel',
+    category: 'Salud y Bienestar',
+    phone: '+529996543210',
+  },
+  {
+    id: 'servicios-1',
+    name: 'Consultoría Caucel Pro',
+    address: 'Calle 19 #42, Caucel',
+    category: 'Servicios Profesionales',
+    phone: '+529995432109',
+  },
+  {
+    id: 'servicios-2',
+    name: 'Despacho Legal Caucel',
+    address: 'Av. 60 #130, Caucel',
+    category: 'Servicios Profesionales',
+    phone: '+529994321098',
+  },
+  {
+    id: 'educacion-1',
+    name: 'Academia Brilla',
+    address: 'Calle 18 #221, Caucel',
+    category: 'Educación',
+    phone: '+529993210987',
+  },
+  {
+    id: 'educacion-2',
+    name: 'Centro de Idiomas Caucel',
+    address: 'Calle 15 #87, Caucel',
+    category: 'Educación',
+    phone: '+529992109876',
+  },
+  {
+    id: 'hogar-1',
+    name: 'Ferretería La Herramienta',
+    address: 'Av. 65 #34, Caucel',
+    category: 'Hogar y Mejoras',
+    phone: '+529991098765',
+  },
+  {
+    id: 'hogar-2',
+    name: 'Decoraciones Casa Viva',
+    address: 'Calle 24 #150, Caucel',
+    category: 'Hogar y Mejoras',
+    phone: '+529990987654',
+  },
+  {
+    id: 'entretenimiento-1',
+    name: 'CineClub Caucel',
+    address: 'Calle 12 #45, Caucel',
+    category: 'Entretenimiento',
+    phone: '+529989876543',
+  },
+  {
+    id: 'entretenimiento-2',
+    name: 'Parque de Diversiones Caucel',
+    address: 'Av. 30 #200, Caucel',
+    category: 'Entretenimiento',
+    phone: '+529988765432',
+  },
+  {
+    id: 'automotriz-1',
+    name: 'Taller Motor Max',
+    address: 'Calle 40 #180, Caucel',
+    category: 'Automotriz',
+    phone: '+529987654321',
+  },
+  {
+    id: 'automotriz-2',
+    name: 'Refaccionaria Ruta 281',
+    address: 'Calle 22 #78, Caucel',
+    category: 'Automotriz',
+    phone: '+529986543210',
+  },
+  {
+    id: 'tecnologia-1',
+    name: 'TechZone Caucel',
+    address: 'Av. 59 #300, Caucel',
+    category: 'Tecnología',
+    phone: '+529985432109',
+  },
+  {
+    id: 'tecnologia-2',
+    name: 'Servicios IT Caucel',
+    address: 'Calle 27 #66, Caucel',
+    category: 'Tecnología',
+    phone: '+529984321098',
+  },
+];
+
+const BusinessListScreen = ({ route, navigation }) => {
+  const category = route?.params?.category ?? null;
+
+  const businesses = useMemo(() => {
+    if (!category) {
+      return BUSINESSES;
+    }
+
+    return BUSINESSES.filter((business) => business.category === category);
+  }, [category]);
+
+  const renderBusiness = ({ item }) => (
+    <View style={styles.card}>
+      <View style={styles.cardInfo}>
+        <Text style={styles.name}>{item.name}</Text>
+        <Text style={styles.address}>{item.address}</Text>
+        {!category && <Text style={styles.category}>{item.category}</Text>}
+      </View>
+
+      <TouchableOpacity
+        style={styles.detailButton}
+        onPress={() => navigation?.navigate('BusinessDetail', { business: item })}
+      >
+        <Text style={styles.detailButtonText}>Ver detalle</Text>
+      </TouchableOpacity>
+    </View>
+  );
+
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Business List Screen</Text>
+      <Text style={styles.header}>
+        {category ? `Negocios de ${category}` : 'Todos los negocios'}
+      </Text>
+
+      <FlatList
+        data={businesses}
+        keyExtractor={(item) => item.id}
+        renderItem={renderBusiness}
+        contentContainerStyle={styles.listContent}
+        ListEmptyComponent={
+          <Text style={styles.emptyMessage}>
+            No hay negocios registrados para esta categoría.
+          </Text>
+        }
+      />
     </View>
   );
 };
@@ -12,12 +174,64 @@ const BusinessListScreen = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
+    backgroundColor: '#f8fafc',
+    paddingHorizontal: 16,
+    paddingTop: 24,
   },
-  title: {
-    fontSize: 24,
-    fontWeight: 'bold',
+  header: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#0f172a',
+    marginBottom: 16,
+  },
+  listContent: {
+    paddingBottom: 24,
+    gap: 12,
+  },
+  card: {
+    backgroundColor: '#ffffff',
+    borderRadius: 12,
+    padding: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 3,
+  },
+  cardInfo: {
+    marginBottom: 12,
+    gap: 4,
+  },
+  name: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#1e293b',
+  },
+  address: {
+    fontSize: 14,
+    color: '#475569',
+  },
+  category: {
+    fontSize: 12,
+    color: '#64748b',
+    textTransform: 'uppercase',
+    fontWeight: '600',
+  },
+  detailButton: {
+    backgroundColor: '#2563eb',
+    borderRadius: 8,
+    paddingVertical: 10,
+    alignItems: 'center',
+  },
+  detailButtonText: {
+    color: '#ffffff',
+    fontWeight: '600',
+    fontSize: 14,
+  },
+  emptyMessage: {
+    textAlign: 'center',
+    color: '#64748b',
+    marginTop: 32,
   },
 });
 

--- a/src/screens/CategoriesScreen.js
+++ b/src/screens/CategoriesScreen.js
@@ -1,10 +1,45 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useCallback } from 'react';
+import { View, Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native';
 
-const CategoriesScreen = () => {
+const CATEGORIES = [
+  'Alimentos y Bebidas',
+  'Salud y Bienestar',
+  'Servicios Profesionales',
+  'Educación',
+  'Hogar y Mejoras',
+  'Entretenimiento',
+  'Automotriz',
+  'Tecnología',
+];
+
+const CategoriesScreen = ({ navigation }) => {
+  const handleCategoryPress = useCallback(
+    (category) => {
+      if (navigation && typeof navigation.navigate === 'function') {
+        navigation.navigate('BusinessList', { category });
+      }
+    },
+    [navigation]
+  );
+
+  const renderCategory = ({ item }) => (
+    <TouchableOpacity
+      style={styles.categoryButton}
+      onPress={() => handleCategoryPress(item)}
+    >
+      <Text style={styles.categoryLabel}>{item}</Text>
+    </TouchableOpacity>
+  );
+
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Categories Screen</Text>
+      <Text style={styles.title}>Categorías</Text>
+      <FlatList
+        data={CATEGORIES}
+        keyExtractor={(item) => item}
+        renderItem={renderCategory}
+        contentContainerStyle={styles.listContent}
+      />
     </View>
   );
 };
@@ -12,12 +47,30 @@ const CategoriesScreen = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
+    paddingHorizontal: 16,
+    paddingTop: 24,
+    backgroundColor: '#FFFFFF',
   },
   title: {
     fontSize: 24,
     fontWeight: 'bold',
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  listContent: {
+    paddingBottom: 24,
+  },
+  categoryButton: {
+    backgroundColor: '#1d4ed8',
+    paddingVertical: 16,
+    borderRadius: 8,
+    marginBottom: 12,
+    alignItems: 'center',
+  },
+  categoryLabel: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '600',
   },
 });
 


### PR DESCRIPTION
## Summary
- implement BusinessList screen with dummy businesses per category and navigation to the detail view
- update Categories screen to forward the selected category to the list screen
- register BusinessList and BusinessDetail routes in the navigator and display passed business information

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb62a8ec70833093911e4cd55a3a31