### PR TITLE
feat: add mock ProfileScreen with user info

### DIFF
--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { View, Text, StyleSheet, Image, TouchableOpacity } from 'react-native';
+
+const ProfileScreen = () => {
+  return (
+    <View style={styles.container}>
+      <Image
+        source={{ uri: 'https://i.pravatar.cc/150?img=12' }}
+        style={styles.avatar}
+      />
+      <Text style={styles.name}>Juan Pérez</Text>
+      <Text style={styles.email}>juan.perez@example.com</Text>
+
+      <TouchableOpacity style={styles.editButton}>
+        <Text style={styles.editButtonText}>✏️ Editar perfil</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#f8fafc',
+    padding: 20,
+  },
+  avatar: {
+    width: 120,
+    height: 120,
+    borderRadius: 60,
+    marginBottom: 20,
+  },
+  name: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: '#0f172a',
+  },
+  email: {
+    fontSize: 16,
+    color: '#475569',
+    marginBottom: 24,
+  },
+  editButton: {
+    backgroundColor: '#2563eb',
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    borderRadius: 8,
+  },
+  editButtonText: {
+    color: '#ffffff',
+    fontWeight: '600',
+    fontSize: 16,
+  },
+});
+
+export default ProfileScreen;


### PR DESCRIPTION
## Summary
- add a profile screen mock showing a sample user with avatar, name, email, and edit button for navigation testing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb6b9881b08330871cad81e5d8dea4